### PR TITLE
Reduce CPU usage

### DIFF
--- a/DereTore.Applications.ScoreEditor/DereTore.Applications.ScoreEditor.csproj
+++ b/DereTore.Applications.ScoreEditor/DereTore.Applications.ScoreEditor.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Controls\DoubleBufferedPictureBox.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="Interop\NativeMethods.cs" />
     <Compile Include="PlayerSettings.cs" />
     <Compile Include="Controls\RenderHelper.cs" />
     <Compile Include="Controls\RenderParams.cs" />

--- a/DereTore.Applications.ScoreEditor/Interop/NativeMethods.cs
+++ b/DereTore.Applications.ScoreEditor/Interop/NativeMethods.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace DereTore.Applications.ScoreEditor.Interop {
+    internal static class NativeMethods {
+        [DllImport("winmm.dll")]
+        public static extern uint timeBeginPeriod(uint uMilliseconds);
+
+        [DllImport("winmm.dll")]
+        public static extern uint timeEndPeriod(uint uMilliseconds);
+
+    }
+}

--- a/DereTore.Applications.ScoreEditor/ThreadingTimer.cs
+++ b/DereTore.Applications.ScoreEditor/ThreadingTimer.cs
@@ -8,6 +8,7 @@ namespace DereTore.Applications.ScoreEditor {
         public readonly uint MMTimerPeriod = 1;
 
         public ThreadingTimer(double interval) {
+            _lock = new object();
             NativeMethods.timeBeginPeriod(MMTimerPeriod);
             Interval = interval;
             _stopwatch = new Stopwatch();
@@ -16,22 +17,31 @@ namespace DereTore.Applications.ScoreEditor {
         public event EventHandler<EventArgs> Elapsed;
 
         public void Start() {
-            if (_stopwatch.IsRunning) {
-                return;
+            lock (_lock) {
+                if (_thread != null) {
+                    return;
+                }
+                _thread = new Thread(ThreadProc) {
+                    IsBackground = true
+                };
+                _continue = true;
+                _thread.Start();
+                Monitor.Wait(_lock);
             }
-            _thread = new Thread(ThreadProc) {
-                IsBackground = true
-            };
-            _continue = true;
-            _thread.Start();
         }
 
         public void Stop() {
-            if (!_stopwatch.IsRunning) {
-                return;
+            lock (_lock) {
+                if (_thread == null) {
+                    return;
+                }
+                try {
+                    _continue = false;
+                    _thread.Join();
+                } finally {
+                    _thread = null;
+                }
             }
-            _continue = false;
-            _thread.Join();
         }
 
         public double Interval { get; }
@@ -44,6 +54,9 @@ namespace DereTore.Applications.ScoreEditor {
         }
 
         private void ThreadProc() {
+            lock (_lock) {
+                Monitor.Pulse(_lock);
+            }
             var stopwatch = _stopwatch;
             stopwatch.Start();
             while (_continue) {
@@ -58,8 +71,9 @@ namespace DereTore.Applications.ScoreEditor {
             stopwatch.Reset();
         }
 
+        private readonly object _lock;
         private Thread _thread;
-        private bool _continue;
+        private volatile bool _continue;
         private readonly Stopwatch _stopwatch;
 
     }

--- a/DereTore.Applications.StarlightDirector.Core/DereTore.Applications.StarlightDirector.Core.csproj
+++ b/DereTore.Applications.StarlightDirector.Core/DereTore.Applications.StarlightDirector.Core.csproj
@@ -62,6 +62,9 @@
     <Compile Include="DirectorHelper.cs" />
     <Compile Include="IntegerIDGenerator.cs" />
     <Compile Include="InternalList.cs" />
+    <Compile Include="Interop\NativeConstants.cs" />
+    <Compile Include="Interop\NativeMethods.cs" />
+    <Compile Include="Interop\NativeStructures.cs" />
     <Compile Include="ObservableDictionary.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StringHasher.cs" />

--- a/DereTore.Applications.StarlightDirector.Core/Interop/NativeConstants.cs
+++ b/DereTore.Applications.StarlightDirector.Core/Interop/NativeConstants.cs
@@ -1,4 +1,4 @@
-﻿namespace DereTore.Applications.StarlightDirector.Interop {
+﻿namespace DereTore.Applications.StarlightDirector.Core.Interop {
     internal static class NativeConstants {
 
         public const int WM_DWMCOLORIZATIONCOLORCHANGED = 0x320;

--- a/DereTore.Applications.StarlightDirector.Core/Interop/NativeMethods.cs
+++ b/DereTore.Applications.StarlightDirector.Core/Interop/NativeMethods.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace DereTore.Applications.StarlightDirector.Interop {
+namespace DereTore.Applications.StarlightDirector.Core.Interop {
     internal static class NativeMethods {
 
         public const string DWMAPI_LIB = "dwmapi.dll";
@@ -24,6 +24,12 @@ namespace DereTore.Applications.StarlightDirector.Interop {
 
         [DllImport("kernel32.dll", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
         public static extern IntPtr GetProcAddress(IntPtr hModule, IntPtr lpProcOrdinal);
+
+        [DllImport("winmm.dll")]
+        public static extern uint timeBeginPeriod(uint uMilliseconds);
+
+        [DllImport("winmm.dll")]
+        public static extern uint timeEndPeriod(uint uMilliseconds);
 
     }
 }

--- a/DereTore.Applications.StarlightDirector.Core/Interop/NativeStructures.cs
+++ b/DereTore.Applications.StarlightDirector.Core/Interop/NativeStructures.cs
@@ -1,4 +1,4 @@
-﻿namespace DereTore.Applications.StarlightDirector.Interop {
+﻿namespace DereTore.Applications.StarlightDirector.Core.Interop {
     internal static class NativeStructures {
 
         public struct DWMCOLORIZATIONPARAMS {

--- a/DereTore.Applications.StarlightDirector/DereTore.Applications.StarlightDirector.csproj
+++ b/DereTore.Applications.StarlightDirector/DereTore.Applications.StarlightDirector.csproj
@@ -183,9 +183,6 @@
     <Compile Include="Extensions\VisualExtensions.cs" />
     <Compile Include="UIHelper.cs" />
     <Compile Include="CommandHelper.cs" />
-    <Compile Include="Interop\NativeConstants.cs" />
-    <Compile Include="Interop\NativeMethods.cs" />
-    <Compile Include="Interop\NativeStructures.cs" />
     <Compile Include="ResourceKeys.cs" />
     <Compile Include="UI\Controls\LineLayer.DependencyProperties.cs" />
     <Compile Include="UI\Controls\LineLayer.xaml.cs">

--- a/DereTore.Applications.StarlightDirector/UI/Windows/MainWindow.xaml.cs
+++ b/DereTore.Applications.StarlightDirector/UI/Windows/MainWindow.xaml.cs
@@ -5,7 +5,7 @@ using System.Windows;
 using System.Windows.Input;
 using DereTore.Applications.StarlightDirector.Entities;
 using DereTore.Applications.StarlightDirector.Extensions;
-using DereTore.Applications.StarlightDirector.Interop;
+using DereTore.Applications.StarlightDirector.Core.Interop;
 
 namespace DereTore.Applications.StarlightDirector.UI.Windows {
     public partial class MainWindow {

--- a/DereTore.Applications.StarlightDirector/UIHelper.cs
+++ b/DereTore.Applications.StarlightDirector/UIHelper.cs
@@ -2,7 +2,7 @@
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
-using DereTore.Applications.StarlightDirector.Interop;
+using DereTore.Applications.StarlightDirector.Core.Interop;
 
 namespace DereTore.Applications.StarlightDirector {
     public static class UIHelper {


### PR DESCRIPTION
Set system timer resolution to 1ms and use Thread.Sleep(1) in ThreadingTimer, instead of CPU intensive spinning.